### PR TITLE
🛡️ Sentinel: Fix JS Syntax Error to restore Email Obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Mixed content risks and potential data exfiltration via images.
 **Learning:** `upgrade-insecure-requests` is a powerful CSP directive supported in `<meta>` tags that transparently upgrades HTTP resource requests to HTTPS, mitigating mixed content on static sites. `img-src data:` is often default but unnecessary, and removing it hardens the site against potential data exfiltration vectors.
 **Prevention:** Audit `img-src` usage and remove `data:` if unused. Always include `upgrade-insecure-requests` in CSP for modern static sites.
+
+## 2026-03-03 - JS Syntax Errors as Security Risks
+**Vulnerability:** A syntax error (detached code block) in a global JS file halted script execution, effectively disabling client-side security features (Email Obfuscation) and UX controls.
+**Learning:** Broken code in one part of a script acts as a Denial of Service for all subsequent logic in that file. In static sites where "security" features like obfuscation or CSP nonce injection rely on client-side JS, reliability is a security prerequisite.
+**Prevention:** Implement pre-commit hooks or CI steps that run a linter (e.g., `eslint`) or syntax checker (e.g., `node -c`) on all JavaScript files to prevent broken code from being deployed.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');


### PR DESCRIPTION
🛡️ Sentinel: Fix JS Syntax Error to restore Email Obfuscation

**Severity:** MEDIUM (Availability/Functionality)

**Vulnerability:**
A syntax error (detached `requestAnimationFrame` block) in `assets/js/custom.js` caused JavaScript execution to halt immediately. This effectively acted as a Denial of Service for all subsequent scripts in the file.

**Impact:**
- **Email Obfuscation Disabled:** The logic to reconstruct email addresses from data attributes never ran, leaving email links unclickable and potentially confusing to users (displaying `[Email Protected]`).
- **Mobile Menu Disabled:** The mobile navigation toggle listener was never attached, breaking site navigation on mobile devices.

**Fix:**
Removed the malformed and redundant code block. Verified that the script now executes correctly and the "Email Us" link displays `info@milosec.com` as intended.

**Verification:**
Ran a Playwright script (`verify_fix.py`) which successfully verified the email text update and captured a screenshot of the working UI.

---
*PR created automatically by Jules for task [12547070186176775079](https://jules.google.com/task/12547070186176775079) started by @milosec*