### PR TITLE
🛡️ Sentinel: Fix JS Syntax Error & Harden CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Mixed content risks and potential data exfiltration via images.
 **Learning:** `upgrade-insecure-requests` is a powerful CSP directive supported in `<meta>` tags that transparently upgrades HTTP resource requests to HTTPS, mitigating mixed content on static sites. `img-src data:` is often default but unnecessary, and removing it hardens the site against potential data exfiltration vectors.
 **Prevention:** Audit `img-src` usage and remove `data:` if unused. Always include `upgrade-insecure-requests` in CSP for modern static sites.
+
+## 2026-03-15 - CSP: form-action and JS Availability
+**Vulnerability:** Missing `form-action` in CSP allows form hijacking; Syntax errors in JS compromise security features (Availability/Integrity).
+**Learning:** JS errors in utility scripts (like email obfuscation) fail silently but effectively deny service. `form-action` IS supported in meta tags and provides defense-in-depth against form injection.
+**Prevention:** Verify syntax of all JS assets. Add `form-action 'self'` to CSP meta tags.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 
 	<!-- Meta/SEO -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; upgrade-insecure-requests;">
+		content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
 	<meta name="referrer" content="strict-origin-when-cross-origin">
 	<meta name="description" content="Strategic IT Consulting, Architecture, Security, and Transformation Services.">
 </head>

--- a/project.mobirise
+++ b/project.mobirise
@@ -75,7 +75,7 @@
         "main": true,
         "title": "Home",
         "meta_descr": "",
-        "header_custom": "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; upgrade-insecure-requests;\"><meta name=\"referrer\" content=\"strict-origin-when-cross-origin\">",
+        "header_custom": "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;\"><meta name=\"referrer\" content=\"strict-origin-when-cross-origin\">",
         "footer_custom": "",
         "html_before": ""
       },


### PR DESCRIPTION
Fixed a critical JS syntax error in `assets/js/custom.js` that was preventing the email obfuscation and mobile menu from working. Also hardened the Content Security Policy (CSP) by adding `form-action 'self'` to prevent form hijacking, mirroring the change in `project.mobirise` for persistence.

---
*PR created automatically by Jules for task [6955019508314204478](https://jules.google.com/task/6955019508314204478) started by @milosec*