### PR TITLE
⚡ Bolt: Optimize window resize listener in mobile menu

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-28 - Optimize Window Resize Listeners
+**Learning:** Using `window.addEventListener('resize', ...)` to manage breakpoint-specific logic (like resetting a mobile menu) is inefficient because the event fires continuously during resize, leading to unnecessary checks and layout thrashing.
+**Action:** Use `window.matchMedia('(min-width: ...)')` and listen to its `change` event instead. This ensures the callback only fires exactly when the breakpoint is crossed, avoiding the performance hit of continuous resize listeners.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -65,12 +50,20 @@ if (menuToggle && navLinks) {
 		});
 	});
 
-	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Reset on resize using matchMedia for better performance
+	const mediaQuery = window.matchMedia('(min-width: 769px)');
+
+	function handleBreakpointChange(e) {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';
 		}
-	});
+	}
+
+	// Listen for changes
+	mediaQuery.addEventListener('change', handleBreakpointChange);
+
+	// Check initial state
+	handleBreakpointChange(mediaQuery);
 }

--- a/search_resize.py
+++ b/search_resize.py
@@ -1,0 +1,7 @@
+with open('assets/js/custom.js', 'r') as f:
+    lines = f.readlines()
+    for i, line in enumerate(lines):
+        if 'resize' in line:
+            start = max(0, i - 2)
+            end = min(len(lines), i + 15)
+            print(''.join(lines[start:end]))

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,61 @@
+import os
+import time
+from playwright.sync_api import sync_playwright
+
+def test_mobile_menu():
+    filepath = f"file://{os.path.abspath('index.html')}"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        # Use a mobile viewport size
+        page = browser.new_page(viewport={"width": 375, "height": 667})
+
+        # We need to abort external requests since CSP might block or upgrade them
+        page.route("**/*", lambda route: route.continue_() if not route.request.url.startswith("http") else route.abort())
+
+        # Catch errors
+        page.on("pageerror", lambda err: print(f"Page Error: {err}"))
+        page.on("console", lambda msg: print(f"Console: {msg.text}"))
+
+        page.goto(filepath)
+
+        # Verify initial state
+        toggle = page.locator('.mobile-menu-toggle')
+        nav_links = page.locator('.nav-links')
+
+        assert toggle.get_attribute('aria-expanded') == 'false', "Menu should be closed initially"
+        assert not 'active' in nav_links.get_attribute('class'), "Nav links should not be active initially"
+
+        # Click toggle
+        toggle.click()
+
+        # Verify expanded state
+        assert toggle.get_attribute('aria-expanded') == 'true', "Menu should be open after click"
+        page.wait_for_function("document.querySelector('.nav-links').classList.contains('active')")
+
+        # Click a link inside the menu to close it
+        nav_links.locator('a').first.click()
+
+        # Verify closed state
+        assert toggle.get_attribute('aria-expanded') == 'false', "Menu should be closed after link click"
+        page.wait_for_function("!document.querySelector('.nav-links').classList.contains('active')")
+
+        # Click toggle again to open
+        toggle.click()
+        assert toggle.get_attribute('aria-expanded') == 'true', "Menu should be open again"
+
+        # Resize window past breakpoint (769px) to test matchMedia reset logic
+        page.set_viewport_size({"width": 800, "height": 600})
+
+        # Add slight delay for matchMedia event to process
+        page.wait_for_timeout(500)
+
+        # Verify menu resets correctly via matchMedia event
+        assert toggle.get_attribute('aria-expanded') == 'false', f"Menu should be closed after resizing to desktop, but got {toggle.get_attribute('aria-expanded')}"
+        page.wait_for_function("!document.querySelector('.nav-links').classList.contains('active')")
+
+        print("All mobile menu tests passed successfully!")
+        browser.close()
+
+if __name__ == '__main__':
+    test_mobile_menu()


### PR DESCRIPTION
💡 **What:** 
Replaced the `window.addEventListener('resize', ...)` for resetting the mobile menu with `window.matchMedia('(min-width: 769px)')` and a `change` listener. Also fixed a critical `SyntaxError` caused by duplicate leftover code from a previous spotlight implementation.

🎯 **Why:** 
The previous `resize` listener fired continuously while the user resized the window, causing unnecessary JavaScript execution and layout checks on every pixel change. The syntax error was breaking all custom JavaScript on the page.

📊 **Impact:** 
Changes complexity of the breakpoint check from firing constantly during a resize event to O(1) by only firing exactly when the 769px breakpoint is crossed. Fixes broken custom JS completely.

🔬 **Measurement:** 
I added Playwright tests to assert that the reset logic still works. You can verify it by opening `index.html`, opening the mobile menu on a narrow screen, and then resizing the window past 768px—the menu state cleanly resets. I verified there are no syntax errors via `node -c assets/js/custom.js`.

---
*PR created automatically by Jules for task [5941330682843704498](https://jules.google.com/task/5941330682843704498) started by @milosec*