### PR TITLE
⚡ Bolt: [performance improvement] Replace resize event listener with matchMedia

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -65,12 +50,16 @@ if (menuToggle && navLinks) {
 		});
 	});
 
-	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Reset on breakpoint crossing instead of continuous resize events
+	const mediaQuery = window.matchMedia('(min-width: 769px)');
+	const handleBreakpointChange = (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';
 		}
-	});
+	};
+	mediaQuery.addEventListener('change', handleBreakpointChange);
+	// Check initial state
+	handleBreakpointChange(mediaQuery);
 }

--- a/tests/verify_menu.py
+++ b/tests/verify_menu.py
@@ -1,0 +1,45 @@
+import sys
+import os
+from playwright.sync_api import sync_playwright
+
+def test_mobile_menu():
+    filepath = os.path.abspath('index.html')
+    url = f'file://{filepath}'
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        # Set mobile viewport size
+        page = browser.new_page(viewport={'width': 375, 'height': 667})
+
+        # Abort external requests to bypass CSP restrictions for file:// URLs
+        page.route("**/*", lambda route: route.continue_() if not route.request.url.startswith("http") else route.abort())
+
+        page.goto(url)
+
+        # Wait for toggle
+        toggle = page.locator('.mobile-menu-toggle')
+        nav_links = page.locator('.nav-links')
+
+        # Verify initial state
+        assert toggle.get_attribute('aria-expanded') == 'false'
+
+        # Click toggle to open menu
+        toggle.click()
+        page.wait_for_timeout(500)
+
+        assert toggle.get_attribute('aria-expanded') == 'true'
+        assert 'active' in nav_links.get_attribute('class')
+
+        # Resize to desktop
+        page.set_viewport_size({'width': 1024, 'height': 768})
+        page.wait_for_timeout(500)
+
+        # Verify reset
+        assert toggle.get_attribute('aria-expanded') == 'false'
+        assert 'active' not in nav_links.get_attribute('class')
+
+        browser.close()
+        print("Mobile menu test passed.")
+
+if __name__ == "__main__":
+    test_mobile_menu()


### PR DESCRIPTION
## What
- Replaced the continuous `window.addEventListener('resize', ...)` on the mobile menu with `window.matchMedia('(min-width: 769px)')`.
- Removed an orphaned `requestAnimationFrame` block that caused a syntax error in `assets/js/custom.js`.

## Why
- Binding events to `resize` causes the callback to fire dozens of times per second while the window is being resized, which causes severe layout thrashing (especially since the logic reads `window.innerWidth`).
- `window.matchMedia` only fires a single event *when the breakpoint boundary is crossed*, making it vastly more efficient for toggling state.
- Fixing the syntax error ensures the optimized script (and the entire site's JavaScript logic) can be parsed and run correctly.

## Impact
- **Reduces Event Firing:** Changes a continuously firing event listener to a single event that only fires when crossing the 768px breakpoint boundary.
- **Prevents Layout Thrashing:** Avoids calling `window.innerWidth` during every resize frame.
- **Restores Functionality:** Removing the syntax error ensures that the mobile menu toggle and email obfuscation scripts actually execute.

## Measurement
- Run `node -c assets/js/custom.js` to ensure there are no syntax errors.
- Run `python3 tests/verify_menu.py` to use Playwright to toggle the menu open on a mobile viewport and confirm it resets cleanly when crossed past the 768px breakpoint boundary to desktop.
- Run `python3 /home/jules/verification/verify_menu_visual.py` to visually review the mobile menu states across the breakpoints.

---
*PR created automatically by Jules for task [13630994605192095190](https://jules.google.com/task/13630994605192095190) started by @milosec*