### PR TITLE
⚡ Bolt: Replace resize listener with matchMedia for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-01 - Resize Event Over-Execution
+**Learning:** `window.addEventListener('resize')` fires continuously during window resizing, causing performance degradation due to unnecessary JS execution and layout checks (like `window.innerWidth`).
+**Action:** Replace resize event listeners that check for breakpoints with `window.matchMedia('(min-width: ...)').addEventListener('change')` to only execute logic when the breakpoint boundary is actually crossed.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -66,8 +51,9 @@ if (menuToggle && navLinks) {
 	});
 
 	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// ⚡ Bolt: Use window.matchMedia instead of window.addEventListener('resize') to prevent layout thrashing and unnecessary executions.
+	window.matchMedia('(min-width: 769px)').addEventListener('change', (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
💡 **What:** 
Replaced `window.addEventListener('resize')` logic that handled resetting the mobile menu with `window.matchMedia('(min-width: 769px)').addEventListener('change', ...)`. Additionally, removed a small block of dead/orphaned code in `assets/js/custom.js` that was resulting in a syntax error. Documented the learning about layout thrashing due to continuous resize listeners in `.jules/bolt.md`.

🎯 **Why:** 
The `resize` event fires continuously (dozens of times per second) while a user resizes their browser window. Checking `window.innerWidth` on every tick causes layout thrashing and unnecessary JS execution. `matchMedia` provides an event that only fires *once*, precisely when the specified breakpoint is crossed, completely eliminating the overhead.

📊 **Impact:** 
Changes execution frequency from O(N) (dozens of times per second during resize) to O(1) (once per breakpoint cross). This reduces main thread blocking and layout recalculations.

🔬 **Measurement:** 
1. Run `node -c assets/js/custom.js` to verify syntax is valid (no errors).
2. Start an HTTP server, resize the browser window past 768px, and observe that the menu successfully resets without continuous JavaScript logs/execution. Tested programmatically via Playwright.

---
*PR created automatically by Jules for task [12017418819292749133](https://jules.google.com/task/12017418819292749133) started by @milosec*