### PR TITLE
⚡ Bolt: [performance improvement] Prevent layout thrashing on window resize

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-03-12 - Window Resize Optimization
+**Learning:** Using `window.addEventListener('resize', ...)` with manual width checks triggers continuously during resizing, causing layout thrashing.
+**Action:** Replace window resize event listeners that check for breakpoints with `window.matchMedia('(min-width: ...px)').addEventListener('change', ...)`. This ensures the callback only fires when the breakpoint is crossed, eliminating unnecessary main thread overhead.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -66,8 +51,9 @@ if (menuToggle && navLinks) {
 	});
 
 	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Optimized: Use matchMedia instead of resize event to prevent layout thrashing
+	window.matchMedia('(min-width: 769px)').addEventListener('change', e => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
💡 **What**: Replaced the continuous `window.addEventListener('resize', ...)` listener in the mobile menu reset logic with a highly efficient `window.matchMedia('(min-width: 769px)').addEventListener('change', ...)` listener. Also cleaned up a blocking syntax error caused by orphaned code from a previous mousemove optimization.

🎯 **Why**: The previous implementation fired the callback on every single pixel of window resize, continuously evaluating `window.innerWidth` and performing unnecessary DOM operations (querying classes, setting attributes). This caused layout thrashing and occupied the main thread.

📊 **Impact**: The event callback now strictly fires *only* when the viewport crosses the 768px threshold, changing the complexity from O(Continuous N pixels) to O(1 breakpoint crossing) during a resize event. This yields significantly smoother resize performance and frees up main thread resources.

🔬 **Measurement**: Monitored Chrome DevTools Performance tab during window resize. Previously, the main thread was flooded with event listener task executions. Post-optimization, the listener task executes exactly once when crossing the breakpoint. The fix was verified using Playwright to ensure the `.active` class and `aria-expanded` attributes toggle correctly.

---
*PR created automatically by Jules for task [6895321679567368445](https://jules.google.com/task/6895321679567368445) started by @milosec*