### PR TITLE
⚡ Bolt: Optimize mobile menu resize listener and fix syntax error

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-01 - Mobile Menu Resize Listener Bottleneck
+**Learning:** Attaching standard `resize` event listeners to `window` for updating component states (like mobile menu resets) causes unnecessary callback execution on every pixel change, leading to performance degradation.
+**Action:** Use `window.matchMedia('(min-width: ...px)').addEventListener('change', ...)` to trigger logic only when specific breakpoints are crossed, rather than continuously polling viewport width.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -66,8 +51,9 @@ if (menuToggle && navLinks) {
 	});
 
 	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Optimized: Use matchMedia instead of resize listener to avoid firing on every pixel change
+	window.matchMedia('(min-width: 769px)').addEventListener('change', (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
💡 What: Replaced standard resize listener with matchMedia for mobile menu reset and removed an orphaned code block causing a syntax error.
🎯 Why: Standard resize listeners on window trigger continuously during a resize, causing unnecessary callback execution on every pixel change and impacting performance. The orphaned code caused a syntax error that broke custom.js entirely.
📊 Impact: Eliminates unnecessary continuous callback executions when resizing the browser window, executing only once when the 769px breakpoint is crossed.
🔬 Measurement: Verified with functional testing via Playwright to confirm the mobile menu resets properly when scaling up to desktop resolution. Node.js syntax check confirmed custom.js is free of syntax errors.

---
*PR created automatically by Jules for task [10940405332794439690](https://jules.google.com/task/10940405332794439690) started by @milosec*