### PR TITLE
⚡ Bolt: Optimize viewport change listener using matchMedia

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-01 - Optimizing Viewport Change Listeners
+**Learning:** Using `window.addEventListener('resize')` for responsive breakpoints causes unnecessary callback execution and layout thrashing because it triggers continuously during resizing, even when the breakpoint hasn't changed.
+**Action:** Replace `window.addEventListener('resize')` with `window.matchMedia('(min-width: ...)').addEventListener('change')` to trigger callbacks only when crossing defined breakpoints.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -65,9 +50,10 @@ if (menuToggle && navLinks) {
 		});
 	});
 
-	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Reset on breakpoint crossing (performance optimized: avoids constant layout thrashing during resize)
+	const mql = window.matchMedia('(min-width: 769px)');
+	mql.addEventListener('change', (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
💡 **What:** 
Replaced `window.addEventListener('resize')` with `window.matchMedia('(min-width: 769px)').addEventListener('change')` for the mobile menu reset logic. Also removed pre-existing broken orphaned spotlight code that was causing a SyntaxError in custom.js.

🎯 **Why:** 
The standard resize event listener fires continuously during window resizing (even if the breakpoint hasn't changed), causing unnecessary callback execution and potentially main thread blocking.

📊 **Impact:** 
Eliminates layout thrashing during window resize events since the reset logic now only executes exactly once when crossing the specified viewport breakpoint.

🔬 **Measurement:** 
1. Run `node -c assets/js/custom.js` to verify there are no longer any SyntaxErrors.
2. Verified using a Playwright script: resizing the viewport from mobile width to desktop width correctly closes the menu and resets its state, matching the exact functionality of the previous code but far more efficiently.

---
*PR created automatically by Jules for task [13980647985613798783](https://jules.google.com/task/13980647985613798783) started by @milosec*