### PR TITLE
⚡ Bolt: Optimize window resize listener with matchMedia

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-01 - Global Resize Listener Bottleneck
+**Learning:** Attaching a `window.addEventListener('resize')` listener to perform conditional breakpoint logic executes on every resize tick, which can cause severe layout thrashing or lag.
+**Action:** Replace inefficient `resize` event listeners with `window.matchMedia('(min-width: <breakpoint>)').addEventListener('change', ...)` to ensure layout changes only trigger when the breakpoint is explicitly crossed.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -65,9 +50,10 @@ if (menuToggle && navLinks) {
 		});
 	});
 
-	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Reset on resize (optimized: use matchMedia to prevent layout thrashing on every resize tick)
+	const mediaQuery = window.matchMedia('(min-width: 769px)');
+	mediaQuery.addEventListener('change', (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
💡 **What:** 
1. Fixed a trailing syntax error left over from a previous optimization in `assets/js/custom.js` that caused all custom logic (like the mobile menu) to fail.
2. Replaced the `window.addEventListener('resize')` listener with `window.matchMedia('(min-width: 769px)').addEventListener('change', ...)`. Added an inline comment explaining this change.

🎯 **Why:** 
Attaching a `window` resize event listener checking `window.innerWidth > 768` on every resize tick causes unnecessary execution and potential layout thrashing. `window.matchMedia` only triggers a `change` event when the breakpoint is crossed, effectively removing the performance bottleneck.

📊 **Impact:** 
Reduces JavaScript execution overhead on window resize by limiting the callback execution exclusively to when the 768px threshold is crossed (O(1) execution instead of O(N) where N is the number of pixels resized).

🔬 **Measurement:**
Run `node -c assets/js/custom.js` to ensure the syntax error is resolved. Open the application, manually resize the window across the 768px breakpoint, and confirm the menu behaves correctly with lower CPU overhead.

---
*PR created automatically by Jules for task [11669003720247589154](https://jules.google.com/task/11669003720247589154) started by @milosec*