### PR TITLE
⚡ Bolt: Replace resize listener with matchMedia

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-01 - Layout Thrashing with Resize Listeners
+**Learning:** Using `window.addEventListener('resize', ...)` to handle responsive breakpoints causes the callback to fire continuously during window resizing, leading to unnecessary checks and potential layout thrashing.
+**Action:** Use `window.matchMedia('(min-width: 769px)').addEventListener('change', ...)` to trigger breakpoint-specific logic only when the breakpoint is actually crossed, rather than on every resize frame.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -66,8 +51,10 @@ if (menuToggle && navLinks) {
 	});
 
 	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Optimized: Use matchMedia instead of resize listener to avoid layout thrashing
+	const mediaQuery = window.matchMedia('(min-width: 769px)');
+	mediaQuery.addEventListener('change', (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
💡 What: Replaced `window.addEventListener('resize')` with `window.matchMedia('(min-width: 769px)').addEventListener('change')` for mobile menu reset logic in `assets/js/custom.js`. Also removed an orphaned/duplicate `requestAnimationFrame` block that was causing a `SyntaxError` which broke the entire script.

🎯 Why: Using a 'resize' event listener causes the callback to fire continuously during window resizing, leading to unnecessary DOM checks and potential layout thrashing. `window.matchMedia` is far more efficient as it only fires precisely when the specified breakpoint is crossed. The removal of the orphaned code block was necessary because the file had a `SyntaxError` (unexpected `}`) preventing any custom JS from executing.

📊 Impact: Reduces main thread blocking during window resizing. Complexity changes from O(frames) to O(1) at the breakpoint. Also restores full functionality of custom JS by fixing the syntax error.

🔬 Measurement: Verified the functionality using a Playwright script that resizes the viewport across the 768px breakpoint and confirmed the mobile menu closes automatically when returning to desktop mode. Validated syntax fix with `node -c assets/js/custom.js`.

Note: The removal of code on lines 14-29 was NOT a feature deletion. It was broken, duplicate code left over from a previous `mousemove` optimization that resulted in an unexpected `}` syntax error. Its removal restores script execution.

---
*PR created automatically by Jules for task [503267430809324746](https://jules.google.com/task/503267430809324746) started by @milosec*