### PR TITLE
⚡ Bolt: Use matchMedia for mobile menu resize listener

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,21 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
-
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
 	const user = link.getAttribute('data-user');
@@ -66,8 +51,8 @@ if (menuToggle && navLinks) {
 	});
 
 	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	window.matchMedia('(min-width: 769px)').addEventListener('change', (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
💡 What: 
- Replaced the continuous `window.addEventListener('resize')` listener on the mobile menu with a targeted `window.matchMedia('(min-width: 769px)').addEventListener('change', ...)` listener.
- Removed an orphaned, duplicate `requestAnimationFrame` code block (lines 15-28) that was causing a pre-existing `SyntaxError` and preventing `custom.js` from parsing entirely.

🎯 Why: 
- Attaching a standard `resize` event listener continuously fires the callback function (and DOM queries) on every single pixel change during a window resize. By using `matchMedia`, the callback is exclusively fired when the viewport crosses the specified breakpoint (768px), making it drastically more efficient. 
- The orphaned code snippet was completely invalid syntax and broke all JavaScript execution within the file. 

📊 Impact: 
- Changes complexity of the responsive listener from constantly polling on every frame during a resize to only executing O(1) exactly when crossing the breakpoint. 

🔬 Measurement:
- Playwright functional verification successfully demonstrated that opening the mobile menu on a mobile viewport and then resizing the window to a desktop viewport correctly closed the menu without errors. 
- Static syntax checking using `node -c assets/js/custom.js` was used to ensure the file correctly parses and the `SyntaxError` has been fully resolved. 
- Visual verification video: `6a2d00f008020da95d7c9b62debd8f14.webm` shows the resize behavior operating normally.

Note for code reviewers: The deletion of the block containing `requestAnimationFrame` and `ticking = false;` starting on line 15 was necessary to fix a pre-existing syntax error (unbalanced braces/orphaned code). It did not remove an active feature; it restored functionality to the entire file.

---
*PR created automatically by Jules for task [2635491794605084263](https://jules.google.com/task/2635491794605084263) started by @milosec*