### PR TITLE
⚡ Bolt: Prevent layout thrashing in spotlight effect & optimize resize listeners

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-02 - Continuous getBoundingClientRect Layout Thrashing
+**Learning:** Even when scoped to a specific element and throttled by `requestAnimationFrame`, calling `getBoundingClientRect()` on every `mousemove` event continuously forces synchronous layout calculations (layout thrashing) which degrades performance.
+**Action:** Cache absolute element coordinates on `mouseenter` using a `WeakMap` (to avoid memory leaks if elements are removed), update the cache only on resize, and calculate relative mouse positions using `e.pageX` and `e.pageY` during `mousemove` to completely eliminate layout thrashing during the animation.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,31 +1,54 @@
 // Optimized spotlight effect: Listeners attached to cards only, and updates throttled via requestAnimationFrame
-document.querySelectorAll('.card').forEach(card => {
-	card.addEventListener('mousemove', e => {
-		const rect = card.getBoundingClientRect();
-		const x = e.clientX - rect.left;
-		const y = e.clientY - rect.top;
+const cardRects = new WeakMap();
 
-		requestAnimationFrame(() => {
-			card.style.setProperty('--mouse-x', `${x}px`);
-			card.style.setProperty('--mouse-y', `${y}px`);
-		});
+function updateCardRect(card) {
+	const rect = card.getBoundingClientRect();
+	cardRects.set(card, {
+		left: rect.left + window.scrollX,
+		top: rect.top + window.scrollY
+	});
+}
+
+document.querySelectorAll('.card').forEach(card => {
+	let ticking = false;
+
+	card.addEventListener('mouseenter', () => {
+		if (!cardRects.has(card)) {
+			updateCardRect(card);
+		}
+	});
+
+	card.addEventListener('mousemove', e => {
+		if (!ticking) {
+			window.requestAnimationFrame(() => {
+				const rect = cardRects.get(card);
+				if (rect) {
+					const x = e.pageX - rect.left;
+					const y = e.pageY - rect.top;
+					card.style.setProperty('--mouse-x', `${x}px`);
+					card.style.setProperty('--mouse-y', `${y}px`);
+				}
+				ticking = false;
+			});
+			ticking = true;
+		}
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
+// Update cached rects on resize
+const updateAllRects = () => {
+	document.querySelectorAll('.card').forEach(card => {
+		if (cardRects.has(card)) {
+			updateCardRect(card);
+		}
+	});
+};
 
-		ticking = true;
-	}
-});
+if (typeof window.smartresize === 'function') {
+	window.smartresize(updateAllRects);
+} else {
+	window.addEventListener('resize', updateAllRects);
+}
 
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {
@@ -65,9 +88,10 @@ if (menuToggle && navLinks) {
 		});
 	});
 
-	// Reset on resize
-	window.addEventListener('resize', () => {
-		if (window.innerWidth > 768) {
+	// Reset on resize (only triggered when crossing breakpoint)
+	const mql = window.matchMedia('(min-width: 769px)');
+	mql.addEventListener('change', (e) => {
+		if (e.matches) {
 			menuToggle.setAttribute('aria-expanded', 'false');
 			navLinks.classList.remove('active');
 			document.body.style.overflow = '';


### PR DESCRIPTION
### 💡 What
1. **Spotlight Effect Optimization:** Eliminated synchronous layout thrashing caused by calling `getBoundingClientRect()` on every `mousemove` event in the card spotlight effect. Coordinates are now cached in a `WeakMap` on `mouseenter`, updated on `resize`, and calculated relative to `e.pageX`/`e.pageY` within a `requestAnimationFrame` callback.
2. **Resize Listener Optimization:** Refactored the mobile menu reset logic from a high-frequency `window.addEventListener('resize')` to an event listener on a `window.matchMedia('(min-width: 769px)')` object. This ensures the callback is only fired when the viewport actually crosses the breakpoint.
3. **Syntax Error Fix:** Removed an orphaned duplicate spotlight code block (lines 14-28) that was causing a `SyntaxError: Unexpected token '}'` and preventing execution.

### 🎯 Why
* **Layout Thrashing:** `getBoundingClientRect()` forces the browser to recalculate layout synchronously. Doing this on every single `mousemove` event severely impacts scrolling and animation framerates, leading to jank.
* **Event Overhead:** The `resize` event fires continuously while a user resizes their browser. Executing DOM queries and style updates constantly is wasteful when the state only needs to change upon crossing a specific breakpoint.

### 📊 Impact
* **Performance:** Reduces main-thread CPU usage during cursor movement over cards from O(N) reflows to O(1) mathematical calculation. Greatly reduces unnecessary DOM manipulations during window resizing. 
* **Reliability:** Restores functionality of custom JavaScript (like the mobile menu) by fixing the blocking syntax error.

### 🔬 Measurement
* Validated no syntax errors using `node -c assets/js/custom.js`.
* Playwright functional verification confirms that `--mouse-x` and `--mouse-y` CSS variables correctly calculate relative pointer positions without triggering continuous layout recalculations.
* Functional verification also confirms the mobile menu correctly transitions from an active state to closed when crossing the 768px breakpoint.

*(Note to reviewers: The removal of code on lines 14-28 was strictly to fix a `SyntaxError` caused by a duplicate, malformed chunk of the spotlight effect leftover from a previous edit. No active features were removed).*

---
*PR created automatically by Jules for task [9651639410053110713](https://jules.google.com/task/9651639410053110713) started by @milosec*