### PR TITLE
⚡ Bolt: GPU offloading for heavy CSS filter animations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2026-02-01 - Global Mousemove Bottleneck
 **Learning:** Attaching `mousemove` listeners to `document` and iterating over all target elements causes massive layout thrashing (`getBoundingClientRect` on every element) and unnecessary style updates.
 **Action:** Attach listeners directly to the target elements and use `requestAnimationFrame` to throttle visual updates. This changes complexity from O(N) to O(1) for the active element.
+
+## 2026-02-01 - GPU Offloading for Heavy CSS Filters
+**Learning:** Animating elements with heavy CSS filters (like `blur(80px)` on `.blob`) on the CPU causes constant main-thread rasterization, leading to layout thrashing and jank.
+**Action:** Apply `will-change: transform;` to offload rendering to the GPU compositor, significantly improving animation performance.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -12,20 +12,6 @@ document.querySelectorAll('.card').forEach(card => {
 	});
 });
 
-		requestAnimationFrame(() => {
-			cards.forEach(card => {
-				const rect = card.getBoundingClientRect();
-				const x = clientX - rect.left;
-				const y = clientY - rect.top;
-				card.style.setProperty('--mouse-x', `${x}px`);
-				card.style.setProperty('--mouse-y', `${y}px`);
-			});
-			ticking = false;
-		});
-
-		ticking = true;
-	}
-});
 
 // Email Obfuscation
 document.querySelectorAll('a[data-user][data-domain]').forEach(link => {

--- a/style.css
+++ b/style.css
@@ -137,6 +137,7 @@ ul {
     opacity: 0.4;
     border-radius: 50%;
     animation: float 20s infinite ease-in-out;
+    will-change: transform;
 }
 
 .blob-1 {


### PR DESCRIPTION
**💡 What:**
Added `will-change: transform;` to the `.blob` CSS class which utilizes heavy `blur(80px)` filters. Additionally, removed dead, orphaned duplicate code from `assets/js/custom.js` that was causing a JavaScript `SyntaxError`.

**🎯 Why:**
Animating heavy CSS filters like `blur()` continuously on the CPU causes constant main-thread rasterization, leading to layout thrashing and animation jank. The orphaned code block in `assets/js/custom.js` was preventing all custom JavaScript from parsing correctly.

**📊 Impact:**
- Offloads rendering to the GPU compositor, significantly improving animation performance.
- Resolves a `SyntaxError` that broke custom JavaScript execution on the frontend.

**🔬 Measurement:**
Visual verification via Playwright confirms the `.blob` element successfully renders and no layout regressions occur. `node -c assets/js/custom.js` passes successfully.

*Note for Code Reviewer: The deleted block in `assets/js/custom.js` was duplicate orphaned code with an unbalanced closing bracket causing a SyntaxError. The active, properly formatted implementation of the spotlight effect on `.card` elements remains intact at the top of the file.*

---
*PR created automatically by Jules for task [11071484374620533268](https://jules.google.com/task/11071484374620533268) started by @milosec*